### PR TITLE
making JSON examples to camelCase

### DIFF
--- a/content/_includes/data-source-configuration.md
+++ b/content/_includes/data-source-configuration.md
@@ -2,8 +2,8 @@
 
 ```json
 {
-  "InputDirectory": "C:\\InputDirectory",
-  "OutputDirectory": "C:\\OutputDirectory"
+  "inputDirectory": "C:\\InputDirectory",
+  "outputDirectory": "C:\\OutputDirectory"
 }
 
 ```
@@ -12,16 +12,16 @@
 
 ```json
 {
-  "FriendlyName": "Weather",
-  "InputDirectory": "C:\\InputDirectory",
-  "FileNameFilter": "*.csv",
-  "OutputDirectory": "C:\\OutputDirectory",
-  "HasHeader": true,
-  "Culture": "fr-FR",
-  "TimeZone": "Europe/Paris",
-  "Compression": "Zip",
-  "FieldSeparator": "|",
-  "PurgeDelay": "5.04:03:02.0000000"
+  "friendlyName": "Weather",
+  "inputDirectory": "C:\\InputDirectory",
+  "fileNameFilter": "*.csv",
+  "outputDirectory": "C:\\OutputDirectory",
+  "hasHeader": true,
+  "culture": "fr-FR",
+  "timeZone": "Europe/Paris",
+  "compression": "Zip",
+  "fieldSeparator": "|",
+  "purgeDelay": "5.04:03:02.0000000"
 }
 ```
 


### PR DESCRIPTION
coverted JSON examples to camelcase per https://dev.azure.com/osieng/engineering/_workitems/edit/274890 

@osisoft-rabrego, our docs' JSON examples have a mix of `camelCase` and `UpperCamelCase`. Converting this examples to camelCase satisfies this story, but in the future, we need to standarize on either camelCase or UpperCamelCase for code examples in all docs. 

@rmuolic , the MS style guide didn't offer any guidance on this, so I suggest we add something to the wiki after we decide.