### PR TITLE
switched selected state for data selection examples

### DIFF
--- a/content/configuration/data-selection.md
+++ b/content/configuration/data-selection.md
@@ -72,7 +72,7 @@ The following are examples of valid Structured Data Files data selection configu
 ```json
 [
   {
-    "Selected": false,
+    "Selected": true,
     "Name": "Name",
     "StreamId": "StreamId",
     "ValueField": "Pressure",
@@ -88,7 +88,7 @@ The following are examples of valid Structured Data Files data selection configu
 ```json
 [
   {
-    "Selected": true,
+    "Selected": false,
     "Name": "Name",
     "StreamId": "StreamId",
     "ValueField": "FanSpeed",


### PR DESCRIPTION
The two examples seems to have switched their 'selected' attribute. The first one just says it has a custom indexFormat, but it's selected attribute is False. The second says it's an unselected item, but its selected attribute is True. I think these should have been switched.