### PR TITLE
Rebrand OSIsoft msg format (379178)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # PI-Adapter-for-Structured-Data-Files-Docs
 
-PI Adapter for Structured Data Files is a data-collection component that transfers time-series data from source devices to OMF (OSIsoft Message Format) endpoints in OSIsoft Cloud Services or PI Servers.
+PI Adapter for Structured Data Files is a data-collection component that transfers time-series data from source devices to Open Message Format (OMF) endpoints in OSIsoft Cloud Services or PI Servers.
 
 This repository contains the documentation for PI Adapter for Structured Data Files.
 
@@ -14,7 +14,7 @@ git subtree pull --prefix content/main https://github.com/osisoft/PI-Adapter mai
 
 ## License
 
-<a href="https://www.osisoft.com/copyright/">&copy; 2020 - 2021 OSIsoft, LLC. All rights reserved.</a>
+<a href="https://www.osisoft.com/copyright/">&copy; 2020 - 2023 OSIsoft, LLC. All rights reserved.</a>
 
 Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at:
 

--- a/classification.xml
+++ b/classification.xml
@@ -410,9 +410,9 @@
    <Row ss:AutoFitHeight="0">
     <Cell ss:StyleID="s75"><Data ss:Type="String">Developer</Data></Cell>
     <Cell ss:StyleID="s74"><Data ss:Type="String">developer</Data></Cell>
-    <Cell><Data ss:Type="String">OSIsoft Message Format (OMF)</Data></Cell>
-    <Cell ss:StyleID="s74"><Data ss:Type="String">OSIsoft-Message-Format</Data></Cell>
-    <Cell><Data ss:Type="String">OSIsoft Message Format (OMF)</Data></Cell>
+    <Cell><Data ss:Type="String">Open Message Format (OMF)</Data></Cell>
+    <Cell ss:StyleID="s74"><Data ss:Type="String">Open-Message-Format</Data></Cell>
+    <Cell><Data ss:Type="String">Open Message Format (OMF)</Data></Cell>
     <Cell ss:Index="7" ss:StyleID="s76"><Data ss:Type="String">Yes</Data></Cell>
    </Row>
    <Row ss:AutoFitHeight="0">
@@ -981,16 +981,16 @@
     <Cell ss:Index="2" ss:StyleID="s89"><Data ss:Type="String">PI-OPC-DA-Server_2018-Patch-1</Data></Cell>
    </Row>
    <Row ss:AutoFitHeight="0" ss:Height="14.4375">
-    <Cell ss:Index="2" ss:StyleID="s88"><Data ss:Type="String">OSIsoft-Message-Format</Data></Cell>
+    <Cell ss:Index="2" ss:StyleID="s88"><Data ss:Type="String">Open-Message-Format</Data></Cell>
    </Row>
    <Row ss:AutoFitHeight="0" ss:Height="14.4375">
-    <Cell ss:Index="2" ss:StyleID="s89"><Data ss:Type="String">OSIsoft-Message-Format-1.2</Data></Cell>
+    <Cell ss:Index="2" ss:StyleID="s89"><Data ss:Type="String">Open-Message-Format-1.2</Data></Cell>
    </Row>
    <Row ss:AutoFitHeight="0" ss:Height="14.4375">
-    <Cell ss:Index="2" ss:StyleID="s90"><Data ss:Type="String">OSIsoft-Message-Format-1.1</Data></Cell>
+    <Cell ss:Index="2" ss:StyleID="s90"><Data ss:Type="String">Open-Message-Format-1.1</Data></Cell>
    </Row>
    <Row ss:AutoFitHeight="0" ss:Height="14.4375">
-    <Cell ss:Index="2" ss:StyleID="s90"><Data ss:Type="String">OSIsoft-Message-Format-1.0</Data></Cell>
+    <Cell ss:Index="2" ss:StyleID="s90"><Data ss:Type="String">Open-Message-Format-1.0</Data></Cell>
    </Row>
    <Row ss:AutoFitHeight="0" ss:Height="14.4375">
     <Cell ss:Index="2" ss:StyleID="s88"><Data ss:Type="String">PI-Web-API</Data></Cell>

--- a/content/main/shared-content/configuration/egress-endpoints/prepare-egress-destinations.md
+++ b/content/main/shared-content/configuration/egress-endpoints/prepare-egress-destinations.md
@@ -4,7 +4,7 @@ uid: PrepareEgressDestinations
 
 # Prepare egress destinations
 
-OCS and PI Server destinations may require additional configuration to receive OMF messages.
+OCS and PI Server destinations may require additional configuration to receive Open Message Format (OMF) messages.
 
 ## OCS
 
@@ -24,7 +24,7 @@ To prepare OCS to receive OMF messages from the adapter, create an OMF connectio
 
 To prepare a PI Server to receive OMF messages from the adapter, a PI Web API OMF endpoint must be available. Complete the following steps:
 
-1. Install PI Web API and enable the **OSIsoft Message Format (OMF) Services** feature.
+1. Install PI Web API and enable the **Open Message Format (OMF) Services** feature.
     
     - During configuration, choose an AF database and PI Data Archive where metadata and data will be stored.
 

--- a/content/release-notes/release-notes.md
+++ b/content/release-notes/release-notes.md
@@ -9,7 +9,7 @@ Adapter Framework [!include[framework-version](../main/shared-content/_includes/
 
 ## Overview
 
-This represents the initial release for PI Adapter for Structured Data Files. This product collects time series data from source files in a local or remote directory to OSIsoft Message Format (OMF) endpoints in OSIsoft Cloud Services or PI Servers. PI Adapter for Structured Data Files can also collect health and diagnostics information. It supports buffering, static and event data collection, and various Windows and Linux-based operating systems as well as containerization.
+This represents the initial release for PI Adapter for Structured Data Files. This product collects time series data from source files in a local or remote directory to Open Message Format (OMF) endpoints in OSIsoft Cloud Services or PI Servers. PI Adapter for Structured Data Files can also collect health and diagnostics information. It supports buffering, static and event data collection, and various Windows and Linux-based operating systems as well as containerization.
 
 **Note:** FTP servers are not supported for this version.
 


### PR DESCRIPTION
Rebranding OSIsoft Message Format to Open Message Format throughout the documentation. 